### PR TITLE
Arbitrary watch -- allow user to manually watch dirs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ by Sphinx plus the following options:
 * ``-p``/``--port`` option to specify the port on which the documentation shall be served (default 8000)
 * ``-H``/``--host`` option to specify the host on which the documentation shall be served (default 127.0.0.1)
 * ``-i``/``--ignore`` multiple allowed, option to specify file ignore glob expression when watching changes, for example: `*.tmp`
+* ``-z``/``--watch`` multiple allowed, option to specify additional directories
+  to watch, for example: `some/extra/dir`
 
 To build a classical Sphinx documentation set, issue the following command::
 

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -203,7 +203,7 @@ def get_parser():
                         default=[],
                         help=('Specify additional directories to watch. May be'
                               ' used multiple times.'),
-                        dest='watched_dirs')
+                        dest='additional_watched_dirs')
 
     for opt, meta in SPHINX_BUILD_OPTIONS:
         if meta is None:
@@ -254,7 +254,7 @@ def main():
 
     server = Server(watcher=LivereloadWatchdogWatcher())
     server.watch(srcdir, builder)
-    for dirpath in args.watched_dirs:
+    for dirpath in args.additional_watched_dirs:
         dirpath = os.path.realpath(dirpath)
         server.watch(dirpath, builder)
     server.watch(outdir)

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -200,6 +200,7 @@ def get_parser():
     parser.add_argument('-H', '--host', type=str, default='127.0.0.1')
     parser.add_argument('-i', '--ignore', action='append', default=[])
     parser.add_argument('-z', '--watch', action='append', metavar='DIR',
+                        default=[],
                         help=('Specify additional directories to watch. May be'
                               ' used multiple times.'),
                         dest='watched_dirs')

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -251,11 +251,12 @@ def main():
         os.makedirs(outdir)
 
     builder = SphinxBuilder(outdir, build_args, ignored)
-
     server = Server(watcher=LivereloadWatchdogWatcher())
+
     server.watch(srcdir, builder)
     for dirpath in args.additional_watched_dirs:
         dirpath = os.path.realpath(dirpath)
         server.watch(dirpath, builder)
     server.watch(outdir)
+
     server.serve(port=args.port, host=args.host, root=outdir)

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -199,6 +199,10 @@ def get_parser():
     parser.add_argument('-p', '--port', type=int, default=8000)
     parser.add_argument('-H', '--host', type=str, default='127.0.0.1')
     parser.add_argument('-i', '--ignore', action='append', default=[])
+    parser.add_argument('-z', '--watch', action='append', metavar='DIR',
+                        help=('Specify additional directories to watch. May be'
+                              ' used multiple times.'),
+                        dest='watched_dirs')
 
     for opt, meta in SPHINX_BUILD_OPTIONS:
         if meta is None:
@@ -245,7 +249,12 @@ def main():
     if not os.path.exists(outdir):
         os.makedirs(outdir)
 
+    builder = SphinxBuilder(outdir, build_args, ignored)
+
     server = Server(watcher=LivereloadWatchdogWatcher())
-    server.watch(srcdir, SphinxBuilder(outdir, build_args, ignored))
+    server.watch(srcdir, builder)
+    for dirpath in args.watched_dirs:
+        dirpath = os.path.realpath(dirpath)
+        server.watch(dirpath, builder)
     server.watch(outdir)
     server.serve(port=args.port, host=args.host, root=outdir)

--- a/sphinx_autobuild/test/test_autobuild.py
+++ b/sphinx_autobuild/test/test_autobuild.py
@@ -5,8 +5,10 @@ sphinx-autobuild tests.
 import mock
 import pytest
 import livereload
+from mock import call
 from watchdog import observers
 
+import sphinx_autobuild
 from sphinx_autobuild import main
 
 
@@ -30,3 +32,42 @@ def test_autobuild(mock_makedirs, mock_serve, mock_schedule):
     mock_makedirs.assert_called_once_with('/output')
     mock_serve.assert_called_once_with(
         host='127.0.0.1', root='/output', port=8000)
+
+
+@pytest.mark.parametrize('sys_args', (
+    ['sphinx-autobuild', '/source', '/output',
+     '--port', '8888',
+     '--host', 'example.org',
+     '--ignore', '/ignored',
+     '--watch', '/external'],
+))
+@mock.patch.object(observers.Observer, 'schedule')
+@mock.patch.object(livereload.Server, 'serve')
+@mock.patch('sphinx_autobuild.SphinxBuilder')
+@mock.patch.object(livereload.Server, 'watch')
+@mock.patch('os.makedirs')
+def test_autobuild_with_options(mock_makedirs,
+                                mock_watch, mock_builder,
+                                mock_serve, mock_schedule):
+    """
+    Test autobuild entry point with host, ignore, and watch options
+    """
+    main()
+    mock_makedirs.assert_called_once_with('/output')
+
+    # --port, --host
+    mock_serve.assert_called_once_with(
+        host='example.org', root='/output', port=8888)
+
+    # --ignore
+    mock_builder.assert_called_once_with(
+        '/output', ['/source', '/output'], ['/ignored'])
+
+    list_cmp_unordered = lambda l_0, l_1: all(elt_0 in l_1 for elt_0 in l_0)
+
+    # --watch
+    # ignore order of calls with `list_cmp_unordered`
+    assert list_cmp_unordered(mock_watch.call_args_list,
+                              [call('/source', mock_builder.return_value),
+                               call('/external', mock_builder.return_value),
+                               call('/output')])


### PR DESCRIPTION
Based on the feature/1-arbitrary-watch branch.

I have rebased, documented, fixed, and tested the feature. I also comprehensively tested the rest of the optional arguments.

Tested both py.test and travis.cl.