### PR TITLE
Support ignoring files using regular expressions

### DIFF
--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -28,6 +28,12 @@ __version__ = '0.5.0'
 __url__ = 'https://github.com/GaretJax/sphinx-autobuild'
 
 
+DEFAULT_IGNORE_REGEX = [
+    r'__pycache__/.*\.py',
+    r'.*\.pyc',
+]
+
+
 class _WatchdogHandler(FileSystemEventHandler):
 
     def __init__(self, watcher, action):
@@ -266,7 +272,10 @@ def main():
     if not os.path.exists(outdir):
         os.makedirs(outdir)
 
-    builder = SphinxBuilder(outdir, build_args, ignored, args.re_ignore)
+    re_ignore = args.re_ignore
+    re_ignore.append(DEFAULT_IGNORE_REGEX)
+
+    builder = SphinxBuilder(outdir, build_args, ignored, re_ignore)
     server = Server(watcher=LivereloadWatchdogWatcher())
 
     server.watch(srcdir, builder)

--- a/sphinx_autobuild/test/test_autobuild.py
+++ b/sphinx_autobuild/test/test_autobuild.py
@@ -60,7 +60,7 @@ def test_autobuild_with_options(mock_makedirs,
 
     # --ignore
     mock_builder.assert_called_once_with(
-        '/output', ['/source', '/output'], ['/ignored'])
+        '/output', ['/source', '/output'], ['/ignored'], [])
 
     # --watch
     calls = [call('/source', mock_builder.return_value),

--- a/sphinx_autobuild/test/test_ignored.py
+++ b/sphinx_autobuild/test/test_ignored.py
@@ -1,0 +1,46 @@
+from sphinx_autobuild import SphinxBuilder
+
+
+class TestWatcher(object):
+    pass
+
+
+class TestBuilder(SphinxBuilder):
+    def __init__(self, ignored=None, regex_ignored=None):
+        super(TestBuilder, self).__init__('', [], ignored, regex_ignored)
+        self.built = []
+
+    def __call__(self, src_path):
+        watcher = TestWatcher()
+        super(TestBuilder, self).__call__(watcher, src_path)
+        return hasattr(watcher, '_action_file')
+
+    def build(self, path):
+        self.built.append(path)
+
+
+def test_no_ignore():
+    builder = TestBuilder()
+    assert builder('test.rst')
+
+
+def test_fnmatch():
+    builder = TestBuilder(ignored=[
+        'test.rst',
+        'test-?.rst',
+        'test'
+    ])
+    assert builder('test1.rst')
+    assert not builder('test.rst')
+    assert not builder('test-2.rst')
+    assert not builder('test/test.rst')
+    assert builder('test1/test.rst')
+
+
+def test_regex():
+    builder = TestBuilder(regex_ignored=[
+        r'__pycache__/.*\.py',
+    ])
+    assert builder('test.py')
+    assert builder('__pycache__/test.rst')
+    assert not builder('__pycache__/test.py')


### PR DESCRIPTION
Fixes #24 by providing an additional argument `-r` to pass in a regular expression to ignore paths.