### PR TITLE
Add capability to select random port and automatically start browser at URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,5 +106,4 @@ document properly::
 	    source \
 	    build/html
 
-
-.. port-for: https://pypi.python.org/pypi/port-for/
+.. _port-for: https://pypi.python.org/pypi/port-for/

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ by Sphinx plus the following options:
 * ``-p``/``--port`` option to specify the port on which the documentation shall be served (default 8000)
 * ``-H``/``--host`` option to specify the host on which the documentation shall be served (default 127.0.0.1)
 * ``-i``/``--ignore`` multiple allowed, option to specify file ignore glob expression when watching changes, for example: `*.tmp`
+* ``-B``/``--open-browser`` automatically open a web browser with the URL for this document
+* ``-s``/``--delay`` delay in seconds before opening browser if ``--open-browser`` was selected (default 5)
 * ``-z``/``--watch`` multiple allowed, option to specify additional directories
   to watch, for example: `some/extra/dir`
 
@@ -62,3 +64,47 @@ Then run with::
 
     make livehtml
 
+
+Automatically starting a browser
+--------------------------------
+
+If you work on multiple Sphinx document repositories at one time (e.g., when
+working with related documents that have cross-referencing intersphinx links),
+managing multiple browser windows and manually selecting port numbers becomes
+difficult and tedious. By selecting ``--port 0`` on the command line,
+sphinx-autobuild will use `port-for`_ to generate a random high-numbered
+port that is not currently being used.
+
+To further simplify life, use the ``-B`` (``--open-browser``) option
+to trigger livereload's capability of automatically opening a browser
+window. Use ``-s`` (``--delay``) to change the number of seconds to
+delay before starting the browser, and you may need to do something
+like the following to ensure that all cached content is removed
+before sphinx-autobuild starts watching files to fully render the
+document properly::
+
+    # Clean out any cached content before starting.
+    make clean 2>/dev/null
+
+    # Background a trigger for initial build of all files.
+    (sleep 1 && touch source/*.rst) &
+
+    sphinx-autobuild -q \
+	    -p 0 \
+	    --open-browser \
+	    --delay 5 \
+	    --ignore "*.swp" \
+	    --ignore "*.pdf" \
+	    --ignore "*.log" \
+	    --ignore "*.out" \
+	    --ignore "*.toc" \
+	    --ignore "*.aux" \
+	    --ignore "*.idx" \
+	    --ignore "*.ind" \
+	    --ignore "*.ilg" \
+	    --ignore "*.tex" \
+	    source \
+	    build/html
+
+
+.. port-for: https://pypi.python.org/pypi/port-for/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ argh>=0.24.1
 pathtools>=0.1.2
 PyYAML>=3.10
 tornado>=3.2
+port_for==0.3.1
 livereload>=2.3.0

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -222,7 +222,8 @@ def get_parser():
     parser.add_argument('-H', '--host', type=str, default='127.0.0.1')
     parser.add_argument('-r', '--re-ignore', action='append', default=[])
     parser.add_argument('-i', '--ignore', action='append', default=[])
-    parser.add_argument('-B', '--open-browser', dest='openbrowser', action='store_true', default=False)
+    parser.add_argument('-B', '--open-browser', dest='openbrowser',
+                        action='store_true', default=False)
     parser.add_argument('-s', '--delay', dest='delay', type=int, default=5)
     parser.add_argument('-z', '--watch', action='append', metavar='DIR',
                         default=[],
@@ -292,6 +293,7 @@ def main():
     server.watch(outdir)
 
     if args.openbrowser is True:
-        server.serve(port=portn, host=args.host, root=outdir, open_url_delay=args.delay)
+        server.serve(port=portn, host=args.host,
+                     root=outdir, open_url_delay=args.delay)
     else:
         server.serve(port=portn, host=args.host, root=outdir)

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -222,6 +222,8 @@ def get_parser():
     parser.add_argument('-H', '--host', type=str, default='127.0.0.1')
     parser.add_argument('-r', '--re-ignore', action='append', default=[])
     parser.add_argument('-i', '--ignore', action='append', default=[])
+    parser.add_argument('-B', '--open-browser', dest='openbrowser', action='store_true', default=False)
+    parser.add_argument('-s', '--delay', dest='delay', type=int, default=5)
     parser.add_argument('-z', '--watch', action='append', metavar='DIR',
                         default=[],
                         help=('Specify additional directories to watch. May be'
@@ -289,4 +291,7 @@ def main():
         server.watch(dirpath, builder)
     server.watch(outdir)
 
-    server.serve(port=args.port, host=args.host, root=outdir)
+    if args.openbrowser is True:
+        server.serve(port=portn, host=args.host, root=outdir, open_url_delay=args.delay)
+    else:
+        server.serve(port=portn, host=args.host, root=outdir)

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import sys
+import port_for
 
 try:
     import pty
@@ -273,6 +274,11 @@ def main():
         os.makedirs(outdir)
 
     re_ignore = args.re_ignore + DEFAULT_IGNORE_REGEX
+
+    if args.port != 0:
+        portn = args.port
+    else:
+        portn = port_for.select_random()
 
     builder = SphinxBuilder(outdir, build_args, ignored, re_ignore)
     server = Server(watcher=LivereloadWatchdogWatcher())


### PR DESCRIPTION
When working with multiple Sphinx document repositories at one time (e.g., when working with related documents that have cross-referencing intersphinx links), I often need to have multiple browser windows active with multiple sphinx-autobuild processes running. It became tedious and difficult to manually give them all unique port numbers and to start browser windows. These two changes allow a script that includes lines like those below to automatically open browser windows for every Sphinx document I am working on as I run sphinx-autobuild.

Sorry that I didn't include documentation changes and tests. I just don't have the time (but the changes are very minor, with a good bang-for-the-buck value, so I wanted to at least contribute them for consideration). 

# Clean out any cached content before starting.
make clean 2>/dev/null

# Background a trigger for initial build of all files.
(sleep 1 && touch source/*.rst) &

sphinx-autobuild -q \
        -p 0 \
        --open-browser \
        --delay 5 \
        --ignore "*.swp" \
        --ignore "*.pdf" \
        --ignore "*.log" \
        --ignore "*.out" \
        --ignore "*.toc" \
        --ignore "*.aux" \
        --ignore "*.idx" \
        --ignore "*.ind" \
        --ignore "*.ilg" \
        --ignore "*.tex" \
        source \
        build/html