### PR TITLE
Added support for livereload >=2.4.1

### DIFF
--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -93,7 +93,7 @@ class LivereloadWatchdogWatcher(object):
             action_file = self._action_file or True  # TODO: Hack (see above)
         return action_file, None
 
-    def watch(self, path, action, delay, ignore=None):
+    def watch(self, path, action, *args, **kwargs):
         """
         Called by the Server instance when a new watch task is requested.
         """

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -93,7 +93,7 @@ class LivereloadWatchdogWatcher(object):
             action_file = self._action_file or True  # TODO: Hack (see above)
         return action_file, None
 
-    def watch(self, path, action, _):
+    def watch(self, path, action, delay, ignore=None):
         """
         Called by the Server instance when a new watch task is requested.
         """


### PR DESCRIPTION
This PR is intended to fix compatibility with livereload version >= 2.4.1
This version of livereload changed the API for watchers. It now expected a keyword parameter called `ignore`.

Fix #39 
Fix #40 