### PR TITLE
Fix TypeError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pathtools>=0.1.2
 PyYAML>=3.10
 tornado>=3.2
 port_for==0.3.1
-livereload>=2.3.0
+livereload>=2.4.1

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -101,7 +101,7 @@ class LivereloadWatchdogWatcher(object):
             action_file = self._action_file or True  # TODO: Hack (see above)
         return action_file, None
 
-    def watch(self, path, action, delay=None, ignore=None):
+    def watch(self, path, action, _delay=None, _ignore=None):
         """
         Called by the Server instance when a new watch task is requested.
         """

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -101,7 +101,7 @@ class LivereloadWatchdogWatcher(object):
             action_file = self._action_file or True  # TODO: Hack (see above)
         return action_file, None
 
-    def watch(self, path, action, _delay=None, _ignore=None):
+    def watch(self, path, action, *args, **kwargs):
         """
         Called by the Server instance when a new watch task is requested.
         """

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -101,7 +101,7 @@ class LivereloadWatchdogWatcher(object):
             action_file = self._action_file or True  # TODO: Hack (see above)
         return action_file, None
 
-    def watch(self, path, action, _):
+    def watch(self, path, action, delay=None, ignore=None):
         """
         Called by the Server instance when a new watch task is requested.
         """


### PR DESCRIPTION
python-livereload's API is changed in v2.4.1.
'ignore' keyword is added to Watcher#watch().
This change brings about TypeError in sphinx-autobuild.

```
$ sphinx-autobuild -b singlehtml source build/singlehtml
Traceback (most recent call last):
  File "/Users/amedama/.virtualenvs/sphinx-ab/bin/sphinx-autobuild", line 11, in <module>
    sys.exit(main())
  File "/Users/amedama/.virtualenvs/sphinx-ab/lib/python3.5/site-packages/sphinx_autobuild/__init__.py", line 280, in main
    server.watch(srcdir, builder)
  File "/Users/amedama/.virtualenvs/sphinx-ab/lib/python3.5/site-packages/livereload/server.py", line 203, in watch
    self.watcher.watch(filepath, func, delay, ignore=ignore)
TypeError: watch() got an unexpected keyword argument 'ignore'
```

Therefore, we should add the parameter to LivereloadWatchdogWatcher#watch().