### PR TITLE
Fixed incompatibility with livereload==2.4.1

### DIFF
--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -101,7 +101,7 @@ class LivereloadWatchdogWatcher(object):
             action_file = self._action_file or True  # TODO: Hack (see above)
         return action_file, None
 
-    def watch(self, path, action, _):
+    def watch(self, path, action, _, **kargs):
         """
         Called by the Server instance when a new watch task is requested.
         """


### PR DESCRIPTION
As of version `v2.4.1` of the `livereload` package, they've decided to include a new argument, `ignore`, when they make their `watch()` call from `Server.watch()`. This causes a TypeError so I just changed the sphinx_autobuild `watch()` signature to capture an undefined number of parameters. 