### PR TITLE
Add --poll to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ by Sphinx plus the following options:
   ``--open-browser`` was selected (default 5)
 * ``-z``/``--watch`` multiple allowed, option to specify additional directories
   to watch, for example: `some/extra/dir`
+* ``--poll`` force polling, useful for Vagrant or VirtualBox `which don't trigger file updates in shared folders <https://www.virtualbox.org/ticket/10660>`_
 
 To build a classical Sphinx documentation set, issue the following command::
 


### PR DESCRIPTION
`--poll` needs documentation. My path to discovering it was by reading closed issues and viewing the source code for the commit that adds it.