### PR TITLE
use the sphinx_build module vs the script

### DIFF
--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -168,7 +168,7 @@ class SphinxBuilder(object):
         sys.stdout.write('-' * (81 - len(pre)))
         sys.stdout.write('\n')
 
-        args = ['sphinx-build'] + self._args
+        args = [sys.executable, '-msphinx_build'] + self._args
         if pty:
             master, slave = pty.openpty()
             stdout = os.fdopen(master)

--- a/sphinx_autobuild/__init__.py
+++ b/sphinx_autobuild/__init__.py
@@ -168,7 +168,7 @@ class SphinxBuilder(object):
         sys.stdout.write('-' * (81 - len(pre)))
         sys.stdout.write('\n')
 
-        args = [sys.executable, '-msphinx_build'] + self._args
+        args = [sys.executable, '-msphinx'] + self._args
         if pty:
             master, slave = pty.openpty()
             stdout = os.fdopen(master)


### PR DESCRIPTION
In the SphinxBuilder, the command launched to start the build was using 'sphinx-build' and therefore retrieving the command from the PATH which is not robust with virtual/conda environments. Now, it uses the python interpreter that is used to run the script itself and use the '-msphinx_build' to call sphinx-build