### PR TITLE
Add a new --exec_script flag to run pre-build command

### DIFF
--- a/sphinx_autobuild/test/test_autobuild.py
+++ b/sphinx_autobuild/test/test_autobuild.py
@@ -17,19 +17,27 @@ def patched_args(sys_args, monkeypatch):
     monkeypatch.setattr('sys.argv', sys_args)
 
 
-@pytest.mark.parametrize('sys_args', (
-    ['sphinx-autobuild', '/source', '/output'],
+@pytest.mark.parametrize('sys_args, with_script', (
+    (['sphinx-autobuild', '/source', '/output'], False),
+    (['sphinx-autobuild', '/source', '/output',
+      '--exec_script', '/script'], True),
 ))
 @mock.patch.object(observers.Observer, 'schedule')
 @mock.patch.object(livereload.Server, 'serve')
-@mock.patch('sphinx_autobuild.SphinxBuilder.build')
+@mock.patch('sphinx_autobuild.SphinxBuilder.execute_script')
+@mock.patch('sphinx_autobuild.SphinxBuilder._build')
 @mock.patch('os.makedirs')
-def test_autobuild(mock_makedirs, mock_builder, mock_serve, mock_schedule):
+def test_autobuild(mock_makedirs, mock_builder, mock_execute_script,
+                   mock_serve, mock_schedule, with_script):
     """
     Test autobuild entry point.
     """
     main()
-    mock_builder.assert_called_once_with()
+    mock_builder.assert_called_once_with(None)
+    if with_script:
+        mock_execute_script.assert_called_once_with()
+    else:
+        mock_execute_script.assert_not_called()
     mock_makedirs.assert_called_once_with('/output')
     mock_serve.assert_called_once_with(
         host='127.0.0.1', root='/output', port=8000)
@@ -40,7 +48,8 @@ def test_autobuild(mock_makedirs, mock_builder, mock_serve, mock_schedule):
      '--port', '8888',
      '--host', 'example.org',
      '--ignore', '/ignored',
-     '--watch', '/external'],
+     '--watch', '/external',
+     '--exec_script', '/script'],
 ))
 @mock.patch.object(observers.Observer, 'schedule')
 @mock.patch.object(livereload.Server, 'serve')
@@ -62,7 +71,8 @@ def test_autobuild_with_options(mock_makedirs,
 
     # --ignore
     mock_builder.assert_called_once_with(
-        '/output', ['/source', '/output'], ['/ignored'], DEFAULT_IGNORE_REGEX)
+        '/output', ['/source', '/output'], ['/ignored'],
+        DEFAULT_IGNORE_REGEX, '/script')
 
     # --watch
     calls = [call('/source', mock_builder.return_value),


### PR DESCRIPTION
Now sphinx-autobuild has the ability to run a script before building.

If the script errors out, sphinx-autobuild will print out a warning, but
otherwise continue.

My use case for this feature:
In my previous workflow of manually rebuilding, I had a script that
would automatically add in an `automodule` directive in the test
documentation. If someone changes what a test script references, I want
the `automodule` directives to also update.

For #69 