### PR TITLE
Update PyYaml Requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 watchdog>=0.7.1
 argh>=0.24.1
 pathtools>=0.1.2
-PyYAML>=3.10
+PyYAML>=5.1
 tornado>=3.2
 port_for==0.3.1
 livereload>=2.3.0


### PR DESCRIPTION
The tests passed, but when running `fab lint` I got the following. I tried running linting under a Python 2.7 and 3.7 virtual environment.

Issue #73