### PR TITLE
Don't depend on sphinx-build on PATH, use sphinx installed on the same interpreter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 home-page = "https://github.com/GaretJax/sphinx_autobuild"
 license = "MIT"
 requires = [
+  "sphinx",
   "watchdog",
   "livereload",
 ]
@@ -34,4 +35,4 @@ sphinx-autobuild = "sphinx_autobuild.__main__:main"
 
 [tool.flit.metadata.requires-extra]
 test = ["mock", "pytest", "pytest-cov"]
-docs = ["sphinx"]
+docs = []

--- a/src/sphinx_autobuild/sphinx.py
+++ b/src/sphinx_autobuild/sphinx.py
@@ -61,7 +61,7 @@ class SphinxBuilder(object):
         sys.stdout.write("-" * (81 - len(pre)))
         sys.stdout.write("\n")
 
-        args = ["sphinx-build"] + self._args
+        args = [sys.executable, '-m', 'sphinx'] + self._args
         if pty:
             master, slave = pty.openpty()
             stdout = os.fdopen(master)


### PR DESCRIPTION
Fixes #58
Fixes #74 

Some of my CI/CD pipelines were failing because of this. The problem arises if `sphinx-build` in the local PATH points to a different python version from the main `sys.executable`.